### PR TITLE
Feature/flatten duble linked list multi level

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,16 @@
+AllCops:
+  NewCops: enable
+  TargetRubyVersion: 3.3.6
+
+Style/Documentation:
+  Enabled: false
+
+Style/FrozenStringLiteralComment:
+  Enabled: false
+
+Metrics/BlockLength:
+  Exclude:
+    - "spec/**/*"
+
+Layout/LineLength:
+  Max: 100

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,4 @@
+source 'https://rubygems.org'
+
+gem 'rspec'
+gem 'rubocop', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,53 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    ast (2.4.2)
+    diff-lcs (1.5.1)
+    json (2.9.0)
+    language_server-protocol (3.17.0.3)
+    parallel (1.26.3)
+    parser (3.3.6.0)
+      ast (~> 2.4.1)
+      racc
+    racc (1.8.1)
+    rainbow (3.1.1)
+    regexp_parser (2.10.0)
+    rspec (3.13.0)
+      rspec-core (~> 3.13.0)
+      rspec-expectations (~> 3.13.0)
+      rspec-mocks (~> 3.13.0)
+    rspec-core (3.13.2)
+      rspec-support (~> 3.13.0)
+    rspec-expectations (3.13.3)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.13.0)
+    rspec-mocks (3.13.2)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.13.0)
+    rspec-support (3.13.2)
+    rubocop (1.69.2)
+      json (~> 2.3)
+      language_server-protocol (>= 3.17.0)
+      parallel (~> 1.10)
+      parser (>= 3.3.0.2)
+      rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 2.9.3, < 3.0)
+      rubocop-ast (>= 1.36.2, < 2.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 2.4.0, < 4.0)
+    rubocop-ast (1.37.0)
+      parser (>= 3.3.1.0)
+    ruby-progressbar (1.13.0)
+    unicode-display_width (3.1.2)
+      unicode-emoji (~> 4.0, >= 4.0.4)
+    unicode-emoji (4.0.4)
+
+PLATFORMS
+  x64-mingw-ucrt
+
+DEPENDENCIES
+  rspec
+  rubocop
+
+BUNDLED WITH
+   2.6.3

--- a/flatten_a_multilevel_dubly_linked_list.rb
+++ b/flatten_a_multilevel_dubly_linked_list.rb
@@ -1,16 +1,31 @@
 # Definition for a Node.
 class Node
-    attr_accessor :val, :prev, :next, :child
-    def initialize(val=nil, prev=nil, next_=nil, child=nil)
-        @val = val
-        @prev = prev
-        @next = next_
-        @child = child
-    end
+  attr_accessor :val, :prev, :next, :child
+
+  def initialize(val = nil, prev = nil, next_ = nil, child = nil)
+    @val = val
+    @prev = prev
+    @next = next_
+    @child = child
+  end
 end
 
 # @param {Node} root
 # @return {Node}
 def flatten(root)
+  return root if root.nil?
 
+  current = root
+  while current
+    current = concatenate_child_list(current) if current.child
+    current = current.next
+  end
+  root
+end
+
+def concatenate_child_list(current)
+  current.child.prev = current
+  current.next.next = current.child
+  current.child = nil
+  current
 end

--- a/flatten_a_multilevel_dubly_linked_list_spec.rb
+++ b/flatten_a_multilevel_dubly_linked_list_spec.rb
@@ -13,9 +13,7 @@ RSpec.describe 'flatten' do
       nodes[i + 1].prev = node if i < nodes.length - 1
 
       # Add child if specified
-      if children[i]
-        node.child = create_linked_list(children[i])
-      end
+      node.child = create_linked_list(children[i]) if children[i]
     end
 
     nodes.first
@@ -46,8 +44,8 @@ RSpec.describe 'flatten' do
     #                   |
     #                   4 -> 5
     head = create_linked_list([1, 2, 3], {
-      1 => [4, 5]
-    })
+                                1 => [4, 5]
+                              })
 
     result = flatten(head)
     expect(list_to_array(result)).to eq([1, 2, 4, 5, 3])
@@ -60,9 +58,9 @@ RSpec.describe 'flatten' do
     #                        |
     #                        7 -> 8
     head = create_linked_list([1, 2, 3, 4], {
-      1 => [5, 6],
-      5 => [7, 8]
-    })
+                                1 => [5, 6],
+                                5 => [7, 8]
+                              })
 
     result = flatten(head)
     expect(list_to_array(result)).to eq([1, 2, 5, 6, 7, 8, 3, 4])

--- a/flatten_a_multilevel_dubly_linked_list_spec.rb
+++ b/flatten_a_multilevel_dubly_linked_list_spec.rb
@@ -1,0 +1,70 @@
+require_relative 'flatten_a_multilevel_dubly_linked_list'
+
+RSpec.describe 'flatten' do
+  def create_linked_list(values, children = {})
+    return nil if values.empty?
+
+    # Create nodes
+    nodes = values.map { |val| Node.new(val) }
+
+    # Connect nodes
+    nodes.each_with_index do |node, i|
+      node.next = nodes[i + 1] if i < nodes.length - 1
+      nodes[i + 1].prev = node if i < nodes.length - 1
+
+      # Add child if specified
+      if children[i]
+        node.child = create_linked_list(children[i])
+      end
+    end
+
+    nodes.first
+  end
+
+  def list_to_array(head)
+    result = []
+    current = head
+    while current
+      result << current.val
+      current = current.next
+    end
+    result
+  end
+
+  it 'handles empty list' do
+    expect(flatten(nil)).to be_nil
+  end
+
+  it 'handles single node' do
+    head = Node.new(1)
+    result = flatten(head)
+    expect(list_to_array(result)).to eq([1])
+  end
+
+  it 'flattens a simple multilevel list' do
+    # Create list: 1 -> 2 -> 3
+    #                   |
+    #                   4 -> 5
+    head = create_linked_list([1, 2, 3], {
+      1 => [4, 5]
+    })
+
+    result = flatten(head)
+    expect(list_to_array(result)).to eq([1, 2, 4, 5, 3])
+  end
+
+  it 'flattens a complex multilevel list' do
+    # Create list: 1 -> 2 -> 3 -> 4
+    #                   |
+    #                   5 -> 6
+    #                        |
+    #                        7 -> 8
+    head = create_linked_list([1, 2, 3, 4], {
+      1 => [5, 6],
+      5 => [7, 8]
+    })
+
+    result = flatten(head)
+    expect(list_to_array(result)).to eq([1, 2, 5, 6, 7, 8, 3, 4])
+  end
+end


### PR DESCRIPTION
# Flatten a multilevel double linked list 

An attempted solution to the leetcode problem [430. Flatten a Multilevel Doubly Linked List](https://leetcode.com/problems/flatten-a-multilevel-doubly-linked-list/)

## Question

You are given a doubly linked list, which contains nodes that have a next pointer, a previous pointer, and an additional **child pointer**. This child pointer may or may not point to a separate doubly linked list, also containing these special nodes. These child lists may have one or more children of their own, and so on, to produce a **multilevel data structure** as shown in the example below.

Given the `head` of the first level of the list, **flatten** the list so that all the nodes appear in a single-level, doubly linked list. Let `curr` be a node with a child list. The nodes in the child list should appear **after** `curr` and **before** `curr.next` in the flattened list.

Return _the `head` of the flattened list. The nodes in the list must have **all** of their child pointers set to `null`._

